### PR TITLE
Hot fix: incidents do not show on the map

### DIFF
--- a/app/src/main/java/com/isc/hermes/controller/incidents/IncidentPointVisualizationController.java
+++ b/app/src/main/java/com/isc/hermes/controller/incidents/IncidentPointVisualizationController.java
@@ -89,7 +89,7 @@ public class IncidentPointVisualizationController {
      * @return a Set of Strings containing the desired types
      */
     private Set<String> getDesiredTypes() {
-        return new HashSet<>(Arrays.asList("Accident", "Social-Event", "Street obstruction"));
+        return new HashSet<>(Arrays.asList("Social Incident"));
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string-array name="incidents_type">
         <item>Accident</item>
         <item>Obstruction</item>
-        <item>Social Event</item>
+        <item>Social Incident</item>
         <item>Street Fix</item>
     </string-array>
     <string-array name="incidents_type_colors">


### PR DESCRIPTION
The filter loads incidents as un-updated, so don't load the incidents on the map.

Filter changed