### PR TITLE
Bug #443 - Advanced filters are not shown in the application

### DIFF
--- a/app/src/main/java/com/isc/hermes/controller/FilterCategoriesController.java
+++ b/app/src/main/java/com/isc/hermes/controller/FilterCategoriesController.java
@@ -93,8 +93,6 @@ public class FilterCategoriesController implements CategoryFilterClickListener {
             categories.add(new CategoryFilter(place.getImageResource(), place.getDisplayName()));
         }
 
-        categories.add(new CategoryFilter(R.drawable.navigation, "Special"));
-
         return categories;
     }
 
@@ -104,11 +102,7 @@ public class FilterCategoriesController implements CategoryFilterClickListener {
      */
     @Override
     public void onLocationCategoryClick(CategoryFilter locationCategory) {
-        if (locationCategory.getNameCategory().equals("Special")) {
-            // TODO: Implement Filter Controller here
-        } else {
-            searchPlacesByTag(locationCategory.getNameCategory());
-        }
+        searchPlacesByTag(locationCategory.getNameCategory());
     }
 
     /**

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -90,21 +90,6 @@
             </LinearLayout>
         </androidx.cardview.widget.CardView>
 
-        <LinearLayout
-            android:layout_width="409dp"
-            android:layout_height="669dp"
-            android:orientation="horizontal"
-            android:paddingTop="65dp"
-            tools:ignore="MissingConstraints"
-            tools:layout_editor_absoluteX="1dp"
-            tools:layout_editor_absoluteY="61dp">
-
-            <include
-                layout="@layout/filters_view"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-        </LinearLayout>
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <com.mapbox.mapboxsdk.maps.MapView
@@ -117,7 +102,19 @@
         mapbox:mapbox_cameraZoom="12">
 
     </com.mapbox.mapboxsdk.maps.MapView>
-
+    <LinearLayout
+        android:paddingTop="65dp"
+        android:layout_width="409dp"
+        android:layout_height="669dp"
+        android:orientation="horizontal"
+        tools:layout_editor_absoluteX="1dp"
+        tools:layout_editor_absoluteY="61dp"
+        tools:ignore="MissingConstraints">
+        <include
+            layout="@layout/filters_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Bug report: Advanced filters are not shown in the application
### Severity: Medium

**Description:**
At the time of running the application, the functionality of the advanced filters that was displayed on the main screen was previously implemented, but with the new features added it disappeared.  
This bug affects the functionality of the advanced filters since without the view, the logic would be useless.

**Steps to reproduce:**
  1. Execute the Hermes application
  2. If you already have an active session, proceed to step 3. Otherwise, you will be presented with the Sign in activity. Sign in with your Gmail account by clicking on the Sign In button.
  3. The application will open, displaying the map of your city.
  4. In the main map view, the advanced filter is missing, which is in the form of a horizontal scroll.

**Expected result:**
On the main screen where the map is displayed, it should show the advanced filters in a horizontal scroll with different tags such as "Hotel", "Restaurants", etc.

**Attachments:**
![image](https://github.com/CampusDelSaber/hermes/assets/97560564/825b1ee1-6d28-40c3-9b93-bfb2e965f442)