### PR TITLE
Fix: Solution in the messange in information Administrator Account Re…

### DIFF
--- a/app/src/main/res/layout/activity_mail_verification.xml
+++ b/app/src/main/res/layout/activity_mail_verification.xml
@@ -26,11 +26,14 @@
         android:id="@+id/MessageCode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="37dp"
+        android:layout_marginStart="15dp"
         android:layout_marginTop="12dp"
-        android:layout_marginEnd="36dp"
+        android:layout_marginEnd="15dp"
         android:layout_marginBottom="18dp"
+        android:paddingLeft="5dp"
+        android:paddingRight="5dp"
         android:text="@string/emailVerificationSent"
+        android:textAlignment="center"
         android:textColor="#000000"
         android:textSize="16sp"
         app:layout_constraintBottom_toTopOf="@+id/emailTextView"
@@ -43,26 +46,25 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="84dp"
+        android:layout_marginTop="20dp"
         android:layout_marginEnd="84dp"
-        android:layout_marginBottom="10dp"
         android:text="@string/userEmail"
         android:textColor="@color/blueLogo"
         android:textSize="16sp"
         android:textStyle="bold"
-        app:layout_constraintBottom_toTopOf="@+id/textView5"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/MessageCode" />
 
     <TextView
-        android:id="@+id/textView5"
+        android:id="@+id/MessageCodeHer"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="111dp"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="22dp"
         android:layout_marginEnd="112dp"
         android:text="@string/enterCodeLabel"
-        android:textColor="#201313"
+        android:textColor="#000000"
         android:textSize="16sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -82,7 +84,7 @@
         app:layout_constraintEnd_toStartOf="@+id/codeTextField2"
         app:layout_constraintHorizontal_bias="0.51"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        app:layout_constraintTop_toBottomOf="@+id/MessageCodeHer" />
 
     <EditText
         android:id="@+id/codeTextField2"
@@ -98,7 +100,7 @@
         android:textIsSelectable="false"
         app:layout_constraintEnd_toStartOf="@+id/codeTextField3"
         app:layout_constraintStart_toEndOf="@+id/codeTextField1"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        app:layout_constraintTop_toBottomOf="@+id/MessageCodeHer" />
 
     <EditText
         android:id="@+id/codeTextField3"
@@ -114,7 +116,7 @@
         android:textIsSelectable="false"
         app:layout_constraintEnd_toStartOf="@+id/codeTextField4"
         app:layout_constraintStart_toEndOf="@+id/codeTextField2"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        app:layout_constraintTop_toBottomOf="@+id/MessageCodeHer" />
 
     <EditText
         android:id="@+id/codeTextField4"
@@ -130,7 +132,7 @@
         android:textIsSelectable="false"
         app:layout_constraintEnd_toStartOf="@+id/codeTextField5"
         app:layout_constraintStart_toEndOf="@+id/codeTextField3"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        app:layout_constraintTop_toBottomOf="@+id/MessageCodeHer" />
 
     <EditText
         android:id="@+id/codeTextField6"
@@ -146,7 +148,7 @@
         android:textIsSelectable="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/codeTextField5"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        app:layout_constraintTop_toBottomOf="@+id/MessageCodeHer" />
 
     <EditText
         android:id="@+id/codeTextField5"
@@ -162,47 +164,46 @@
         android:textIsSelectable="false"
         app:layout_constraintEnd_toStartOf="@+id/codeTextField6"
         app:layout_constraintStart_toEndOf="@+id/codeTextField4"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        app:layout_constraintTop_toBottomOf="@+id/MessageCodeHer" />
 
     <Button
         android:id="@+id/cancelButton"
         android:layout_width="168dp"
         android:layout_height="59dp"
-        android:layout_marginTop="100dp"
+        android:layout_marginTop="150dp"
         android:layout_marginEnd="160dp"
         android:layout_marginBottom="164dp"
         android:backgroundTint="@color/mapboxRedDark"
         android:foregroundGravity="center_horizontal"
-
         android:onClick="continueLikeGeneralUser"
-        android:text="Continue General Account"
+        android:text="@string/GeneralAccount"
         android:textAlignment="center"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.361"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        app:layout_constraintTop_toBottomOf="@+id/MessageCodeHer" />
 
     <Button
         android:id="@+id/continueButton"
         android:layout_width="159dp"
         android:layout_height="59dp"
-        android:layout_marginTop="100dp"
+        android:layout_marginTop="150dp"
         android:layout_marginEnd="30dp"
         android:layout_marginBottom="164dp"
         android:backgroundTint="@android:color/holo_green_dark"
         android:onClick="continueVerification"
-        android:text="Verify Account"
+        android:text="@string/VerifyAccount"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.642"
         app:layout_constraintStart_toEndOf="@+id/cancelButton"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        app:layout_constraintTop_toBottomOf="@+id/MessageCodeHer" />
 
     <TextView
         android:id="@+id/titleVerify"
         android:layout_width="348dp"
-        android:layout_height="36dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
         android:layout_marginEnd="31dp"
         android:layout_marginBottom="11dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,8 +19,10 @@
     <string name="userEmail"> sebastian.faustino@example.com</string>
     <string name="enterCodeLabel"> Please enter the code here</string>
     <string name="resendLabel"> did not get an email ? Resend</string>
-    <string name="verifyEmailTittle">Verify admin user request </string>
-    <string name="emailVerificationSent"> An email with verification code has been sent to</string>
+    <string name="verifyEmailTittle"> Administrator Account Request </string>
+    <string name="emailVerificationSent"> Your request is being processed, please check your email, until the request is approved. </string>
+    <string name="VerifyAccount"> Verify Account.</string>
+    <string name="GeneralAccount"> Continue General Account.</string>
     <string name="log_out_text">Log out</string>
     <string name="account_text">Account</string>
     <string name="delete_account_question_text">Are you sure you want to delete your account?</string>


### PR DESCRIPTION
**Describe the bug**
Instructions in the verification code don't follow the project structure.

**To Reproduce**
Steps to reproduce the behavior:
1. Install Hermes app.
2. Click on the "Sign in with Google" button.
3. Enter Google credentials by existing account or by input.
4. Select the "Administrator" item on the selector.
5. Click on the "Sign Up" button.
6. The app will display a screen to enter a verification code.
7. Notify that instructions in the screen says that the verification email has been sent to the final user, not to hermes.info.app

**Expected behavior**
As a normal user that is sign up first time in application, the instructions in screen aren't clear, because it's says a verification code will be sending to my personal email, but this feature don't work on that way, because the verification code first is sended to hermes.info.app account; once development team is agree that user is able to be an admin, the team must re-send this same email to personal user acocunt, letter must be changed for something like "Development team is processing your requesting, please check your email until you can be admin", change the content of current instruction.

**Screenshots**
![ice_screenshot_20230627-173739](https://github.com/CampusDelSaber/hermes/assets/135620337/a6b7f60b-7f92-42f5-8b39-ca55d6a13b78)


**Desktop (please complete the following information):**
 - OS: Windows 10 pro
 - IDE: 
Android Studio Flamingo | 2022.2.1 Patch 2
Build #AI-222.4459.24.2221.10121639, built on May 12, 2023
Runtime version: 17.0.6+0-b2043.56-9586694 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Windows 10 10.0
GC: G1 Young Generation, G1 Old Generation
Memory: 1280M
Cores: 12


**Smartphone :**
 - Device: Xiaomi POCO F3
 - OS: Android 11

**Link to Issue in Test Lodge:**
- [Open Case No. 2](https://app.testlodge.com/a/37307/projects/55109/runs/704533?tab=2)

