### PR TITLE
Bug ID-187 The filter bar is superimposed on the mapbox orientation icon

### DIFF
--- a/app/src/main/java/com/isc/hermes/MainActivity.java
+++ b/app/src/main/java/com/isc/hermes/MainActivity.java
@@ -10,6 +10,7 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.Gravity;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageButton;
@@ -116,6 +117,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         }
 
         Timber.plant(new Timber.DebugTree());
+        changeCompassPosition();
     }
 
 
@@ -524,5 +526,19 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
                                 .getPolygonPoints().toString()
                 );
         IncidentsUploader.getInstance().uploadIncident(JsonString);
+    }
+
+    /**
+     * This method change the compass position in the map.
+     */
+    public void changeCompassPosition(){
+        mapView.getMapAsync(new OnMapReadyCallback() {
+            @Override
+            public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+                mapboxMap.getUiSettings().setCompassEnabled(true);
+                mapboxMap.getUiSettings().setCompassGravity(Gravity.TOP | Gravity.END);
+                mapboxMap.getUiSettings().setCompassMargins(0, 110, 10, 0);
+            }
+        });
     }
 }


### PR DESCRIPTION
What did I do?
Fix the position of the compass so that it is not displayed behind the filters.

How did I do it?
I set the compass position.

bug #187 

![image](https://github.com/CampusDelSaber/hermes/assets/101665677/8a5f17c9-f883-45ce-9cbd-a9bb2ead6c88)



Reviewers:
@Karvlox 
@denisgandel 
@JuanPabloArequipa 