### PR TITLE
#211 Search Engine Allows Input of Words Exceeding 80 Characters

### DIFF
--- a/app/src/main/java/com/isc/hermes/SearchViewActivity.java
+++ b/app/src/main/java/com/isc/hermes/SearchViewActivity.java
@@ -3,6 +3,8 @@ package com.isc.hermes;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.text.InputFilter;
+import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.SearchView;
 import android.widget.Toast;
@@ -67,6 +69,11 @@ public class SearchViewActivity extends AppCompatActivity implements WayPointCli
     private void setupSearchView() {
         searcherController = new SearcherController(searcher, adapterUpdater);
         searchView.setOnQueryTextListener(searcherController.getOnQueryTextListener());
+        int id = searchView.getContext().getResources().getIdentifier("android:id/search_src_text", null, null);
+        EditText editText = (EditText) searchView.findViewById(id);
+        InputFilter[] filters = new InputFilter[1];
+        filters[0] = new InputFilter.LengthFilter(80);
+        editText.setFilters(filters);
         searchView.requestFocus();
     }
 


### PR DESCRIPTION
What?
Fixed the bug where the search is allowed to enter more than 80 characters. 

How?
Applying a restriction of 80 characters to the search view. 

Why?
To avoid errors in the application performance and improve the user's search experience. 