### PR TITLE
Bug/ID-180-overlapping-action-messages-with-sign-up-button-in-user-re…

### DIFF
--- a/app/src/main/java/com/isc/hermes/AccountInformation.java
+++ b/app/src/main/java/com/isc/hermes/AccountInformation.java
@@ -63,7 +63,6 @@ public class AccountInformation extends AppCompatActivity {
     private void generateActionToComboBox() {
         generateComponentsToComboBox().setOnItemClickListener((parent, view, position, id) -> {
             String item = parent.getItemAtPosition(position).toString();
-            Toast.makeText(getApplicationContext(), "Item: " + item, Toast.LENGTH_SHORT).show();
         });
     }
 

--- a/app/src/main/java/com/isc/hermes/UserSignUpCompletionActivity.java
+++ b/app/src/main/java/com/isc/hermes/UserSignUpCompletionActivity.java
@@ -82,8 +82,6 @@ public class UserSignUpCompletionActivity extends AppCompatActivity {
         generateComponentsToComboBox().setOnItemClickListener((parent, view, position, id) -> {
             String item = parent.getItemAtPosition(position).toString();
             UserRepository.getInstance().getUserContained().setTypeUser(item);
-            Toast.makeText(getApplicationContext(), "Item: " + item,
-                    Toast.LENGTH_SHORT).show();
         });
     }
 


### PR DESCRIPTION
**Description:**
The bug has been fixed so that the action, error and success messages should be displayed correctly in the user interface, with proper readability, without contrast problems between text and background, and without overlapping any field or button, this will help to easily read the messages and complete the registration process without any visual obstacle.

**Demo**

https://github.com/CampusDelSaber/hermes/assets/135137641/d8607134-2f27-4a52-95d4-4dd97ed56742

**Issue**
[#180](https://github.com/CampusDelSaber/hermes/issues/180)

**Reviewers:**
Team A: @Karvlox
Team B: @JeferssonCL 
Team C: @fabianromeroclaros

**Trainer (General Reviewer):**
@mmoralesv